### PR TITLE
replace tweenmax with gsap in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": {
     "jquery": "~1.9.1",
-    "tweenMax": "git@github.com:greensock/GreenSock-JS.git#latest"
+    "gsap": "1.11.5"
   }
 }


### PR DESCRIPTION
It's a bad idea to use a github repo when a package is available in bower repo, btw It's gives me error when I want to install ScrollMagic using bower, I thought this tiny patch may fix the issue:

``` bash
bower install ScrollMagic --save
bower ScrollMagic#*             cached git://github.com/janpaepke/ScrollMagic.git#1.0.1
bower ScrollMagic#*           validate 1.0.1 against git://github.com/janpaepke/ScrollMagic.git#*
bower tweenMax#*            not-cached git@github.com:greensock/GreenSock-JS.git#*
bower tweenMax#*               resolve git@github.com:greensock/GreenSock-JS.git#*
bower jquery#~1.9.1             cached git://github.com/jquery/jquery.git#1.9.1
bower jquery#~1.9.1           validate 1.9.1 against git://github.com/jquery/jquery.git#~1.9.1
bower jquery#>= 1.9.0           cached git://github.com/jquery/jquery.git#2.1.0
bower jquery#>= 1.9.0         validate 2.1.0 against git://github.com/jquery/jquery.git#>= 1.9.0
bower tweenMax#*               ECMDERR Failed to execute "git ls-remote --tags --heads git@github.com:greensock/GreenSock-JS.git", exit code of #128

Additional error details:
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
```
