### PR TITLE
Update jQuery to 1.11.0 in Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "js/jquery.scrollmagic.min.js"
   ],
   "dependencies": {
-    "jquery": "~1.9.1",
+    "jquery": "~1.11.0",
     "gsap": "1.11.5"
   }
 }


### PR DESCRIPTION
The demo site uses the latest `1.11.0` so I figure this should be fine.
