### PR TITLE
Destroy debug indicators when scene is destroyed

### DIFF
--- a/js/jquery.scrollmagic.debug.js
+++ b/js/jquery.scrollmagic.debug.js
@@ -130,6 +130,9 @@ Greensock License info at http://www.greensock.com/licensing/
 			};
 			scene.on("change.debug", callUpdate);
 			cParams.container.on("resize scroll", callUpdate);
+			scene.on("destroy", function() {
+				scene.indicators.remove();
+			});
 			if (!cParams.isDocument) {
 				$(window).on("scroll resize", callUpdate);
 			}


### PR DESCRIPTION
This was annoying me when I was trying to debug some strange behaviour after destroying and creating a new instance of ScrollMagic (I thought the actual scene wasn't destroying properly before realising it was old indicators).