### PR TITLE
Better npm/browserify support

### DIFF
--- a/dev/src/ScrollMagic.js
+++ b/dev/src/ScrollMagic.js
@@ -8,6 +8,9 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		module.exports = factory();
 	} else {
 		// Browser global
 		root.ScrollMagic = factory();

--- a/dev/src/plugins/animation.gsap.js
+++ b/dev/src/plugins/animation.gsap.js
@@ -20,6 +20,11 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(['ScrollMagic', 'TweenMax', 'TimelineMax'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		// Loads whole gsap package onto global scope.
+		require('gsap');
+		factory(require('scrollmagic'), TweenMax, TimelineMax);
 	} else {
 		// Browser globals
 		factory(root.ScrollMagic || (root.jQuery && root.jQuery.ScrollMagic), root.TweenMax || root.TweenLite, root.TimelineMax || root.TimelineLite);

--- a/dev/src/plugins/animation.velocity.js
+++ b/dev/src/plugins/animation.velocity.js
@@ -20,6 +20,9 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(['ScrollMagic', 'velocity'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('scrollmagic'), require('velocity'));
 	} else {
 		// Browser globals
 		factory(root.ScrollMagic || (root.jQuery && root.jQuery.ScrollMagic), root.Velocity || (root.jQuery && root.jQuery.Velocity));

--- a/dev/src/plugins/debug.addIndicators.js
+++ b/dev/src/plugins/debug.addIndicators.js
@@ -13,6 +13,9 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['ScrollMagic'], factory);
+    } else if (typeof exports === 'object') {
+    		// CommonJS
+    		factory(require('scrollmagic'));
     } else {
     		// no browser global export needed, just execute
         factory(root.ScrollMagic || (root.jQuery && root.jQuery.ScrollMagic));

--- a/dev/src/plugins/jquery.ScrollMagic.js
+++ b/dev/src/plugins/jquery.ScrollMagic.js
@@ -25,6 +25,9 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(['ScrollMagic', 'jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('scrollmagic'), require('jquery'));
 	} else {
 		// Browser global
 		factory(root.ScrollMagic, root.jQuery);


### PR DESCRIPTION
Fix plugin dependencies.
Export ScrollMagic directly.
Support gsap’s strange exports.