### PR TITLE
Fix npm and bower package name in github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,10 +168,10 @@
                     <code class="cdn active item">
                     </code>
                     <code class="bower item">
-                        bower install ScrollMagic
+                        bower install scrollmagic
                     </code>
                     <code class="npm item">
-                        npm install ScrollMagic
+                        npm install scrollmagic
                     </code>
                     <div class="item download">
                         <a href="https://github.com/janpaepke/ScrollMagic/zipball/master"><i class="fa fa-download"></i> Download (zip)</a>


### PR DESCRIPTION
This is a pull request to rename the two package names to lowercase to match latest scrollmagic package versions.

As of now, they don't work anymore in CamelCase. Packages are not found.