### PR TITLE
update scroll offset before updating pin state

### DIFF
--- a/dev/src/ScrollMagic/Scene.js
+++ b/dev/src/ScrollMagic/Scene.js
@@ -98,7 +98,6 @@ ScrollMagic.Scene = function (options) {
 				}
 			})
 			.on("shift.internal", function (e) {
-				updateScrollOffset();
 				Scene.update(); // update scene to reflect new position
 			});
 	};
@@ -110,6 +109,10 @@ ScrollMagic.Scene = function (options) {
 	// @include('Scene/getters-setters.js')
 	
 	// @include('Scene/event-management.js')
+
+    Scene.on("shift.internal", function(e) {
+        updateScrollOffset();
+    });
 	
 	// @include('Scene/feature-pinning.js')
 


### PR DESCRIPTION
Hi Jan, I'm working on a website where I change the scroll position if the window gets resized. I do that so that the user sees the same section even though the contents shift. Doing so I run into a bug: if the current section was pinned (fixed), it got a wrong offset.
Basically this fix makes sure that updateScrollOffset() gets called before updatePinState().