### PR TITLE
Npm package is "scrollmagic", not "ScrollMagic"

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
                         bower install ScrollMagic
                     </code>
                     <code class="npm item">
-                        npm install ScrollMagic
+                        npm install scrollmagic
                     </code>
                     <div class="item download">
                         <a href="https://github.com/janpaepke/ScrollMagic/zipball/master"><i class="fa fa-download"></i> Download (zip)</a>


### PR DESCRIPTION
Without this fix, installing the package gives this error:

> 'ScrollMagic' is not in the npm registry