### PR TITLE
Added instanceof check for NodeList for Safari compatibility

### DIFF
--- a/scrollmagic/uncompressed/ScrollMagic.js
+++ b/scrollmagic/uncompressed/ScrollMagic.js
@@ -2660,7 +2660,7 @@
 					return arr;
 				}
 			}
-			if (_type(selector) === 'nodelist' || _type.Array(selector)) {
+			if (_type(selector) === 'nodelist' || _type.Array(selector) || selector instanceof NodeList) {
 				for (var i = 0, ref = arr.length = selector.length; i < ref; i++) { // list of elements
 					var elem = selector[i];
 					arr[i] = _type.DomElement(elem) ? elem : _get.elements(elem); // if not an element, try to resolve recursively


### PR DESCRIPTION
My call to `.setPin()` was working find in Chrome, but in Safari I was getting `ERROR calling method 'setPin()': Invalid pin element supplied.`.  The issue appeared to stem from the following:

In Chrome

```
var selector = document.querySelectorAll('.my-class')
typeof selector === "[object NodeList]"
Object.prototype.toString.call(selector).replace(/^\[object (.+)\]$/, "$1").toLowerCase() === 'nodelist'
```

However, in Safari

```
var selector = document.querySelectorAll('.my-class')
typeof selector === "[object Object]"
Object.prototype.toString.call(selector).replace(/^\[object (.+)\]$/, "$1").toLowerCase() === 'object'
selector instanceof NodeList === true
```
