### PR TITLE
velocity plugin - fix for npm/browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     }
   ],
   "main": "scrollmagic/uncompressed/ScrollMagic.js",
+  "browser": {
+    "velocity": "velocity-animate"
+  },
   "engines": {
     "node": "0.10.x"
   },


### PR DESCRIPTION
Velocity has different name in npm registry.
Without this patch animation.velocity plugin is not working when used with browserify.

PS: It's a temporary fix if https://github.com/julianshapiro/velocity/issues/574 will be resolved.
