### PR TITLE
[fix] semicolon causes scope error 

### DIFF
--- a/dev/src/ScrollMagic/Scene/feature-pinning.js
+++ b/dev/src/ScrollMagic/Scene/feature-pinning.js
@@ -359,7 +359,7 @@ this.removePin = function (reset) {
 			if (pinTarget.hasAttribute(PIN_SPACER_ATTRIBUTE)) { // copy margins to child spacer
 				var
 					style = _pinOptions.spacer.style,
-					values = ["margin", "marginLeft", "marginRight", "marginTop", "marginBottom"];
+					values = ["margin", "marginLeft", "marginRight", "marginTop", "marginBottom"],
 					margins = {};
 				values.forEach(function (val) {
 					margins[val] = style[val] || "";

--- a/scrollmagic/uncompressed/ScrollMagic.js
+++ b/scrollmagic/uncompressed/ScrollMagic.js
@@ -2277,7 +2277,7 @@
 					if (pinTarget.hasAttribute(PIN_SPACER_ATTRIBUTE)) { // copy margins to child spacer
 						var
 						style = _pinOptions.spacer.style,
-							values = ["margin", "marginLeft", "marginRight", "marginTop", "marginBottom"];
+							values = ["margin", "marginLeft", "marginRight", "marginTop", "marginBottom"],
 						margins = {};
 						values.forEach(function (val) {
 							margins[val] = style[val] || "";


### PR DESCRIPTION
I use the uncompressed and see this scope error.
I only replace the semicolon by a comma.
