### PR TITLE
Fixed centered pin offset problem

### DIFF
--- a/dev/src/ScrollMagic/Scene/feature-pinning.js
+++ b/dev/src/ScrollMagic/Scene/feature-pinning.js
@@ -131,6 +131,11 @@ var updatePinDimensions = function () {
 			css["padding" + (vertical ? "Top" : "Left")] = _options.duration * _progress;
 			css["padding" + (vertical ? "Bottom" : "Right")] = _options.duration * (1 - _progress);
 		}
+
+		// Preserve the width of the pin spacer. When the _pin is set to 'fixed', the pin spacer would collapse to 0,
+		// and if it is horizontally centered (with flex or auto margin), its `left` would change.
+		css["width"] = _util.get.width(_pin);
+
 		_util.css(_pinOptions.spacer, css);
 	}
 };


### PR DESCRIPTION
If a pin is horizontally centered and its width is fixed (or auto
width), taking it out of document flow by setting its position to fixed
would cause the pin spacer to collapse to 0.

The left offset of the pin spacer moves to the right because its width
is now zero. This causes the pin to jump to the right as well.

See a demo of this problem: http://codepen.io/hayeah/pen/GppjgN
