### PR TITLE
Fix Pin behavior in zoomed viewports

### DIFF
--- a/scrollmagic/uncompressed/ScrollMagic.js
+++ b/scrollmagic/uncompressed/ScrollMagic.js
@@ -1595,7 +1595,7 @@
 					containerOffset[param] -= _controller.scrollPos();
 				}
 
-				elementPos = elementOffset[param] - containerOffset[param];
+				elementPos = Math.round(elementOffset[param] - containerOffset[param]);
 			}
 			var changed = elementPos != _triggerPos;
 			_triggerPos = elementPos;


### PR DESCRIPTION
Chrome returns subpixel positions for zoomed viewports. This makes float comparison fail in `changed` check two lines below.