### PR TITLE
setToggleClass fails when given space separated list of css classes

### DIFF
--- a/dev/src/ScrollMagic/Scene/feature-classToggles.js
+++ b/dev/src/ScrollMagic/Scene/feature-classToggles.js
@@ -33,12 +33,14 @@ this.setClassToggle = function (element, classes) {
 		// remove old ones
 		Scene.removeClassToggle();
 	}
-	_cssClasses = classes;
+	_cssClasses = classes.split(" ");
 	_cssClassElems = elems;
 	Scene.on("enter.internal_class leave.internal_class", function (e) {
 		var toggle = e.type === "enter" ? _util.addClass : _util.removeClass;
 		_cssClassElems.forEach(function (elem, key) {
-			toggle(elem, _cssClasses);
+			_cssClasses.forEach(function(cssClass) {
+				toggle(elem, cssClass);
+			});
 		});
 	});
 	return Scene;


### PR DESCRIPTION
DOMTokenList accepts one single token as argument (according to MDN). In
Chrome, .add("a","b","c") is possible. If given a space separated list
of classes, Chrome throws the following error:

Uncaught InvalidCharacterError: Failed to execute 'add' on
'DOMTokenList': The token provided ('red enbiggen') contains HTML space
characters, which are not valid in tokens.

See: http://codepen.io/hayeah/pen/QjjQLY