### PR TITLE
Fixed SVG element detection as Dom Element and related Error on Safari

### DIFF
--- a/dev/src/ScrollMagic/_util.js
+++ b/dev/src/ScrollMagic/_util.js
@@ -148,7 +148,7 @@ var _util = ScrollMagic._util = (function (window) {
 	};
 	_type.DomElement = function (o){
 		return (
-			typeof HTMLElement === "object" ? o instanceof HTMLElement : //DOM2
+			typeof HTMLElement === "object" || typeof HTMLElement === "function"? o instanceof HTMLElement || o instanceof SVGElement : //DOM2
 			o && typeof o === "object" && o !== null && o.nodeType === 1 && typeof o.nodeName==="string"
 		);
 	};


### PR DESCRIPTION
**Issue**: Passing an svg dom element, or selector string to `setPin()` or `setClassToggle()` causes Safari to throw exception 

> "ERROR calling method 'setPin()': Invalid pin element supplied."

**How to replicate**: Just pass a selector string targeting an inline svg node to the above mentioned functions, and watch out for errors on Safari console. (tested on Safari 9.0 Mac OSX)

**Cause**: The code to parse a selector isn't accurate and hence does not work for SVG elements. Detection of DOM element does not take into account inline svg elements currently. 

**Proposed Fix**: According to comments on [this stackoverflow answer](http://stackoverflow.com/a/384380/3210476) (which uses similar code) , and my testing, Safari says `typeof` `HTMLElement` is an "`object`" while chrome says its a "`function`". Added a check for both according the comments. 
Also, I additionally check to see if the element is an `instanceof SVGElement` and return true for a valid DOM Element.
