### PR TITLE
Memory leaks fixed

### DIFF
--- a/dev/src/ScrollMagic/Scene/core.js
+++ b/dev/src/ScrollMagic/Scene/core.js
@@ -131,7 +131,7 @@ this.destroy = function (reset) {
 	Scene.trigger("destroy", {reset: reset});
 	Scene.remove();
 	//need to clear triggerElement reference avoid memory leaks and detached dom nodes
-    Scene.triggerElement(null);
+        Scene.triggerElement(null);
 	Scene.off("*.*");
 	log(3, "destroyed " + NAMESPACE + " (reset: " + (reset ? "true" : "false") + ")");
 	return null;

--- a/dev/src/ScrollMagic/Scene/core.js
+++ b/dev/src/ScrollMagic/Scene/core.js
@@ -130,6 +130,8 @@ this.remove = function () {
 this.destroy = function (reset) {
 	Scene.trigger("destroy", {reset: reset});
 	Scene.remove();
+	//need to clear triggerElement reference avoid memory leaks and detached dom nodes
+    Scene.triggerElement(null);
 	Scene.off("*.*");
 	log(3, "destroyed " + NAMESPACE + " (reset: " + (reset ? "true" : "false") + ")");
 	return null;

--- a/dev/src/ScrollMagic/Scene/feature-pinning.js
+++ b/dev/src/ScrollMagic/Scene/feature-pinning.js
@@ -380,6 +380,8 @@ this.removePin = function (reset) {
 		_pin.removeEventListener("mousewheel", onMousewheelOverPin);
 		_pin.removeEventListener("DOMMouseScroll", onMousewheelOverPin);
 		_pin = undefined;
+		//remove reference to spacer elements to avoid memory leaks and avoid detached dom nodes
+		_pinOptions.spacer = null;
 		log(3, "removed pin (reset: " + (reset ? "true" : "false") + ")");
 	}
 	return Scene;


### PR DESCRIPTION
Removed unnecessary references to triggerElement and spacer element which were leaking memory and were leading to large number of detached dom nodes in case of single page apps such as angular.

Fixes https://github.com/janpaepke/ScrollMagic/issues/510
