### PR TITLE
Fixes spelling errors on simple pinning example

### DIFF
--- a/examples/basic/simple_pinning.html
+++ b/examples/basic/simple_pinning.html
@@ -32,7 +32,7 @@
 						<h1>Simple Pinning</h1>
 						<h2>Two examples of basic pinning.</h2>
 						<ol>
-							<li>A pin of a scene that has a duration will be pinned for the repective ammount of scrolled pixels and then released again.</li>
+							<li>A pin of a scene that has a duration will be pinned for the respective amount of scrolled pixels and then released again.</li>
 							<li>If no duration is defined, the pinned element will never be released unless scrolling back past the trigger position.</li>
 						</ol>
 						<p>


### PR DESCRIPTION
Just noticed these spelling errors while checking out the examples. Figured I put in a PR 👍 