### PR TITLE
Isomorphic 'window is undefined' error fix

### DIFF
--- a/dev/src/ScrollMagic.js
+++ b/dev/src/ScrollMagic.js
@@ -18,6 +18,10 @@
 }(this, function () {
 	"use strict";
 
+	if(typeof(window) === 'undefined'){
+		return;
+	}
+
 	var ScrollMagic = function () {
 		_util.log(2, '(COMPATIBILITY NOTICE) -> As of ScrollMagic 2.0.0 you need to use \'new ScrollMagic.Controller()\' to create a new controller instance. Use \'new ScrollMagic.Scene()\' to instance a scene.');
 	};


### PR DESCRIPTION
Issue with isomorphic apps that share a codebase on both server and client failing due to window being undefined on server side.  Adding a couple lines of code here will fix this problem as isomorphic apps are becoming more popular.