### PR TITLE
Increase fps limit for mobile support(advance) example.

### DIFF
--- a/examples/expert/mobile_advanced.html
+++ b/examples/expert/mobile_advanced.html
@@ -100,7 +100,7 @@
 
 								// thanks to iScroll 5 we now have a real onScroll event (with some performance drawbacks)
 								myScroll.on("scroll", function () {
-									controller.update();
+									controller.update(true);
 								});
 
 								// add indicators to scrollcontent so they will be moved with it.


### PR DESCRIPTION
as iScroll's scroll event is fired by raf,  update should be immediately. If nest one more raf, the max fps will be only 30.