### PR TITLE
fixed passive error on event listener

### DIFF
--- a/dev/src/ScrollMagic.js
+++ b/dev/src/ScrollMagic.js
@@ -25,7 +25,10 @@
 	ScrollMagic.version = "%VERSION%";
 
 	// TODO: temporary workaround for chrome's scroll jitter bug
-	window.addEventListener("mousewheel", function () {});
+	window.addEventListener("mousewheel", function () {}, {
+		capture: true,
+		passive: true
+	});
 
 	// global const
 	var PIN_SPACER_ATTRIBUTE = "data-scrollmagic-pin-spacer";

--- a/scrollmagic/uncompressed/ScrollMagic.js
+++ b/scrollmagic/uncompressed/ScrollMagic.js
@@ -34,7 +34,10 @@
 	ScrollMagic.version = "2.0.5";
 
 	// TODO: temporary workaround for chrome's scroll jitter bug
-	window.addEventListener("mousewheel", function () {});
+	window.addEventListener("mousewheel", function () {}, {
+		capture: true,
+		passive: true
+	});
 
 	// global const
 	var PIN_SPACER_ATTRIBUTE = "data-scrollmagic-pin-spacer";


### PR DESCRIPTION
Fixing alert on chrome as below
`ScrollMagic.min.js:formatted:8 [Violation] Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952`

Please publish new version yourself if pull is successful