### PR TITLE
Check if window exists to avoid errors

### DIFF
--- a/dev/src/ScrollMagic.js
+++ b/dev/src/ScrollMagic.js
@@ -25,7 +25,7 @@
 	ScrollMagic.version = "%VERSION%";
 
 	// TODO: temporary workaround for chrome's scroll jitter bug
-	window.addEventListener("mousewheel", function () {});
+	typeof(window) !== 'undefined' && window.addEventListener("mousewheel", function () {});
 
 	// global const
 	var PIN_SPACER_ATTRIBUTE = "data-scrollmagic-pin-spacer";


### PR DESCRIPTION
See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html ReferenceError: window is not defined


  36 | 	// TODO: temporary workaround for chrome's scroll jitter bug
> 37 | 	window.addEventListener("mousewheel", function () {});
     | 	^
  38 |
  39 | 	// global const
  40 | 	var PIN_SPACER_ATTRIBUTE = "data-scrollmagic-pin-spacer";