### PR TITLE
Use HTTPS in all URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To get your copy of ScrollMagic you have the choice between four options:
 Download a zip file containing the source code, demo page, all examples and documentation from the [GitHub releases page](https://github.com/janpaepke/ScrollMagic/releases) or clone the package to your machine using the git command line interface:
 
 ```bash
-git clone git://github.com/janpaepke/ScrollMagic.git
+git clone https://github.com/janpaepke/ScrollMagic.git
 ```
 
 **Option 2: Bower**  
@@ -82,15 +82,15 @@ npm install scrollmagic
 If you don't want to host ScrollMagic yourself, you can include it from [cdnjs](https://cdnjs.com/libraries/ScrollMagic):
 
 ```
-http://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.7/ScrollMagic.min.js
+https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.7/ScrollMagic.min.js
 ```
 
 All plugins and uncompressed files are also available on cdnjs.  
 For example:
 
 ```
-http://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.7/plugins/debug.addIndicators.js
-http://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.7/plugins/debug.addIndicators.min.js
+https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.7/plugins/debug.addIndicators.js
+https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.7/plugins/debug.addIndicators.min.js
 ```
 
 ## Installation


### PR DESCRIPTION
This avoids suggesting that developers pull down the library using an insecure protocol.