### PR TITLE
Update CDN links to use HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
                     "cdnjs.cloudflare.com/ajax/libs/ScrollMagic/%version%/plugins/debug.addIndicators.min.js",
                 ];
                 var cdnCode = cdnLinks.map(function(link) {
-                    return '<script src="//' + link.replace(/%version%/gim, ScrollMagic.version) + '"></script' + '>';
+                    return '<script src="https://' + link.replace(/%version%/gim, ScrollMagic.version) + '"></script' + '>';
                 }).join("\n");
 
                 $("<pre>").text(cdnCode).appendTo("#get-it-now code.cdn");


### PR DESCRIPTION
Protocol agnostic/relative URLs are unneeded these days - let's just make them always HTTPS.

The guy who coined them, Paul Irish, [says as much](https://www.paulirish.com/2010/the-protocol-relative-url/):

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, **this technique is now an anti-pattern**. If the asset you need is available on SSL, then **always** use the `https://` asset.